### PR TITLE
Add initial Prisma schema

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -35,7 +35,7 @@ enum TaskStatus {
   IN_REVIEW
   DONE
   CANCELLED
-  FREEZED
+  FROZEN
 }
 
 enum TaskPriority {
@@ -79,7 +79,7 @@ model Task {
 enum ProjectStatus {
   OPEN
   ARCHIVED
-  FREEZED
+  FROZEN
 }
 
 model Project {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -6,3 +6,111 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+enum AccountStatus {
+  PENDING
+  ACTIVE
+  SUSPENDED
+  ARCHIVED
+}
+
+model User {
+  id           String               @id @default(uuid()) @db.Uuid
+  email        String               @unique @db.VarChar(255)
+  passwordHash String               @db.VarChar
+  status       AccountStatus        @default(PENDING)
+  displayName  String?              @db.VarChar(64)
+  username     String               @unique @db.VarChar(32)
+  createdAt    DateTime             @default(now())
+  updatedAt    DateTime             @updatedAt
+  birthDate    DateTime?
+  ownProjects  Project[]
+  projects     ProjectParticipant[]
+  tasks        Task[]
+}
+
+enum TaskStatus {
+  OPEN
+  IN_PROGRESS
+  IN_REVIEW
+  DONE
+  CANCELLED
+  FREEZED
+}
+
+enum TaskPriority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+model Tag {
+  id    String @id @default(uuid()) @db.Uuid
+  name  String @db.VarChar(64)
+  color String @db.VarChar(50)
+  tasks Task[]
+}
+
+model CheckListItem {
+  id          String  @id @default(uuid()) @db.Uuid
+  title       String  @db.VarChar(100)
+  isCompleted Boolean
+  task        Task    @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  taskId      String  @db.Uuid
+}
+
+model Task {
+  id          String          @id @default(uuid()) @db.Uuid
+  title       String          @db.VarChar(100)
+  description String?         @db.Text
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
+  deadline    DateTime?
+  status      TaskStatus      @default(OPEN)
+  priority    TaskPriority
+  projectId   String          @db.Uuid
+  project     Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  creatorId   String          @db.Uuid
+  creator     User            @relation(fields: [creatorId], references: [id])
+  tags        Tag[]
+  checkList   CheckListItem[]
+}
+
+enum ProjectStatus {
+  OPEN
+  ARCHIVED
+  FREEZED
+}
+
+model Project {
+  id           String               @id @default(uuid()) @db.Uuid
+  name         String               @db.VarChar(64)
+  description  String?              @db.Text
+  createdAt    DateTime             @default(now())
+  updatedAt    DateTime             @updatedAt
+  color        String?              @db.VarChar(48)
+  status       ProjectStatus        @default(OPEN)
+  creatorId    String               @db.Uuid
+  creator      User                 @relation(fields: [creatorId], references: [id])
+  tasks        Task[]
+  participants ProjectParticipant[]
+}
+
+enum ParticipantRole {
+  GUEST
+  USER
+  ADMIN
+  OWNER
+}
+
+model ProjectParticipant {
+  id        String          @id @default(uuid()) @db.Uuid
+  role      ParticipantRole
+  joinedAt  DateTime        @default(now())
+  projectId String          @db.Uuid
+  project   Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  userId    String          @db.Uuid
+  user      User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, userId])
+}

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -3,6 +3,16 @@ import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
+  constructor() {
+    super({
+      omit: {
+        user: {
+          passwordHash: true,
+        },
+      },
+    });
+  }
+
   async onModuleInit() {
     await this.$connect();
   }


### PR DESCRIPTION
Introduce a comprehensive Prisma schema with models and enums for user, task, project, and participant. Configure the Prisma service to omit the passwordHash field from the user model by default.