### PR TITLE
Fix query params leak between DTOs

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -18,6 +18,7 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
+      whitelist: true,
     })
   );
 


### PR DESCRIPTION
Set whitelist option to true in class-validator options to avoid query params leak when using multiple DTOs, parsing query params.