### PR TITLE
Fix bugs with missed participant status usage

### DIFF
--- a/apps/api/src/project/guards/project-roles.guard.ts
+++ b/apps/api/src/project/guards/project-roles.guard.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ParticipantRole } from '@prisma/client';
+import { ParticipantRole, ParticipantStatus } from '@prisma/client';
 import { Request } from 'express';
 
 import { PrismaService } from '@/prisma/prisma.service';
@@ -46,6 +46,7 @@ export class ProjectRolesGuard implements CanActivate {
     const participant = await this.prisma.projectParticipant.findUnique({
       where: {
         projectId_userId: { userId, projectId },
+        status: ParticipantStatus.JOINED,
       },
     });
 

--- a/apps/api/src/project/project.service.ts
+++ b/apps/api/src/project/project.service.ts
@@ -1,5 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { ParticipantRole, Prisma, Project } from '@prisma/client';
+import {
+  ParticipantRole,
+  ParticipantStatus,
+  Prisma,
+  Project,
+} from '@prisma/client';
 
 import { Include, mapInclude } from '@/common/include';
 import { OffsetPagination } from '@/common/pagination';
@@ -24,6 +29,7 @@ export class ProjectService {
         ...rest,
         participants: {
           create: {
+            status: ParticipantStatus.JOINED,
             role: ParticipantRole.OWNER,
             userId: creatorId,
           },


### PR DESCRIPTION
1. Check participant status in project roles guard
2. Set owner status to "joined" on project creation