### PR TITLE
Fix issue with title rewrite in projects nested routes

### DIFF
--- a/apps/web/src/app/(user)/projects/[id]/layout.tsx
+++ b/apps/web/src/app/(user)/projects/[id]/layout.tsx
@@ -12,7 +12,6 @@ import {
   PlusIcon,
   UserPenIcon,
 } from 'lucide-react';
-import { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import React, { ReactNode } from 'react';
@@ -21,7 +20,7 @@ import ViewModeSwitch from '@/components/ViewModeSwitch';
 import DeleteProjectDropdownItem from '@/features/project/DeleteProjectDropdownItem';
 import LeaveProjectDropdownItem from '@/features/project/LeaveProjectDropdownItem';
 import { apiFetch } from '@/lib/api-fetch.server';
-import { Project, ProjectWithInclude } from '@/types/project';
+import { ProjectWithInclude } from '@/types/project';
 import { User } from '@/types/user';
 
 type Props = {
@@ -30,18 +29,6 @@ type Props = {
     id: string;
   }>;
 };
-
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
-  const project = await apiFetch<Project>(
-    `/projects/${id}?include=tasks,participants`,
-    { next: { tags: [`project-${id}`] } }
-  );
-
-  return {
-    title: project.name,
-  };
-}
 
 const Layout = async ({ children, params }: Props) => {
   const { id } = await params;

--- a/apps/web/src/app/(user)/projects/[id]/tasks/[taskId]/page.tsx
+++ b/apps/web/src/app/(user)/projects/[id]/tasks/[taskId]/page.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@workspace/ui/components/button';
+import { ArrowLeftIcon } from 'lucide-react';
+import { Metadata } from 'next';
+import Link from 'next/link';
+import React from 'react';
+
+import FullTaskCard from '@/features/task/FullTaskCard';
+import { apiFetch } from '@/lib/api-fetch.server';
+import { Task, TaskWithInclude } from '@/types/task';
+
+type Props = {
+  params: Promise<{
+    id: string;
+    taskId: string;
+  }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { taskId } = await params;
+  const task = await apiFetch<Task>(`/tasks/${taskId}?include=tags,creator`, {
+    next: { tags: [`tasks-${taskId}`] },
+  });
+
+  return {
+    title: `Task "${task.title}"`,
+    description: task.description,
+  };
+}
+
+const Page = async ({ params }: Props) => {
+  const { id, taskId } = await params;
+  const task = await apiFetch<TaskWithInclude<'tags' | 'creator'>>(
+    `/tasks/${taskId}?include=tags,creator`,
+    { next: { tags: [`tasks-${taskId}`] } }
+  );
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex gap-4 justify-between">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground gap-2"
+          asChild
+        >
+          <Link href={`/projects/${id}`}>
+            <ArrowLeftIcon /> Back
+          </Link>
+        </Button>
+      </div>
+      <FullTaskCard task={task} />
+    </div>
+  );
+};
+
+export default Page;


### PR DESCRIPTION
Move metadata from projects layout to page to avoid rewrite of title template, set in root layout for nested routes.