### PR TITLE
Fix issue with title rewrite in projects nested routes

### DIFF
--- a/apps/web/src/app/(user)/projects/[id]/layout.tsx
+++ b/apps/web/src/app/(user)/projects/[id]/layout.tsx
@@ -12,7 +12,6 @@ import {
   PlusIcon,
   UserPenIcon,
 } from 'lucide-react';
-import { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import React, { ReactNode } from 'react';
@@ -21,7 +20,7 @@ import ViewModeSwitch from '@/components/ViewModeSwitch';
 import DeleteProjectDropdownItem from '@/features/project/DeleteProjectDropdownItem';
 import LeaveProjectDropdownItem from '@/features/project/LeaveProjectDropdownItem';
 import { apiFetch } from '@/lib/api-fetch.server';
-import { Project, ProjectWithInclude } from '@/types/project';
+import { ProjectWithInclude } from '@/types/project';
 import { User } from '@/types/user';
 
 type Props = {
@@ -30,18 +29,6 @@ type Props = {
     id: string;
   }>;
 };
-
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
-  const project = await apiFetch<Project>(
-    `/projects/${id}?include=tasks,participants`,
-    { next: { tags: [`project-${id}`] } }
-  );
-
-  return {
-    title: project.name,
-  };
-}
 
 const Layout = async ({ children, params }: Props) => {
   const { id } = await params;

--- a/apps/web/src/app/(user)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(user)/projects/[id]/page.tsx
@@ -1,5 +1,9 @@
+import { Metadata } from 'next';
+
 import TasksKanbanPreloader from '@/features/task/TasksKanbanPreloader';
 import TasksListPreloader from '@/features/task/TasksListPreloader';
+import { apiFetch } from '@/lib/api-fetch.server';
+import { Project } from '@/types/project';
 
 type Props = {
   params: Promise<{
@@ -9,6 +13,18 @@ type Props = {
     viewMode?: string;
   }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const project = await apiFetch<Project>(
+    `/projects/${id}?include=tasks,participants`,
+    { next: { tags: [`project-${id}`] } }
+  );
+
+  return {
+    title: project.name,
+  };
+}
 
 const Page = async ({ params, searchParams }: Props) => {
   const { id } = await params;


### PR DESCRIPTION
Move metadata from projects layout to page to avoid rewrite of title template, set in root layout for nested routes