### PR TITLE
Move user tasks search from user controller to user-task controller

### DIFF
--- a/apps/api/src/task/task.module.ts
+++ b/apps/api/src/task/task.module.ts
@@ -4,10 +4,11 @@ import { PrismaModule } from '@/prisma/prisma.module';
 
 import { TaskController } from './task.controller';
 import { TaskService } from './task.service';
+import { UserTaskController } from './user-task.controller';
 
 @Module({
   imports: [PrismaModule],
-  controllers: [TaskController],
+  controllers: [TaskController, UserTaskController],
   providers: [TaskService],
   exports: [TaskService],
 })

--- a/apps/api/src/task/user-task.controller.ts
+++ b/apps/api/src/task/user-task.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Query } from '@nestjs/common';
+
+import { CurrentUser } from '@/auth/decorators/current-user.decorator';
+import { OffsetPaginationDto } from '@/common/pagination';
+
+import { SearchTasksFilterDto } from './dto/search-tasks-filter.dto';
+import { SearchTasksResponseDto } from './dto/search-tasks-response.dto';
+import { SearchTasksSortDto } from './dto/search-tasks-sort.dto';
+import { TaskIncludeDto } from './dto/task-include.dto';
+import { TaskService } from './task.service';
+
+@Controller('users')
+export class UserTaskController {
+  constructor(private readonly taskService: TaskService) {}
+
+  @Get('me/tasks')
+  async searchMy(
+    @CurrentUser('sub') creatorId: string,
+    @Query() pagination: OffsetPaginationDto,
+    @Query() filter: SearchTasksFilterDto,
+    @Query() sort: SearchTasksSortDto,
+    @Query() include: TaskIncludeDto
+  ): Promise<SearchTasksResponseDto> {
+    const [nodes, totalCount] = await this.taskService.search(
+      { skip: pagination.skip, take: pagination.take },
+      { ...filter, creatorId },
+      sort,
+      include
+    );
+
+    return { nodes, totalCount };
+  }
+}

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -13,11 +13,6 @@ import {
 import { CurrentUser } from '@/auth/decorators/current-user.decorator';
 import { JwtAuthGuard } from '@/auth/guards/jwt-auth.guard';
 import { OffsetPaginationDto } from '@/common/pagination';
-import { SearchTasksFilterDto } from '@/task/dto/search-tasks-filter.dto';
-import { SearchTasksResponseDto } from '@/task/dto/search-tasks-response.dto';
-import { SearchTasksSortDto } from '@/task/dto/search-tasks-sort.dto';
-import { TaskIncludeDto } from '@/task/dto/task-include.dto';
-import { TaskService } from '@/task/task.service';
 
 import { SearchUsersFilterDto } from './dto/search-users-filter.dto';
 import { SearchUsersResponseDto } from './dto/search-users-response.dto';
@@ -30,10 +25,7 @@ import { UserService } from './user.service';
 @UseGuards(JwtAuthGuard)
 @Controller('users')
 export class UserController {
-  constructor(
-    private readonly userService: UserService,
-    private readonly taskService: TaskService
-  ) {}
+  constructor(private readonly userService: UserService) {}
 
   @Get()
   async search(
@@ -45,24 +37,6 @@ export class UserController {
     const [nodes, totalCount] = await this.userService.search(
       { skip: pagination.skip, take: pagination.take },
       filter,
-      sort,
-      include
-    );
-
-    return { nodes, totalCount };
-  }
-
-  @Get('me/tasks')
-  async searchMyTasks(
-    @CurrentUser('sub') creatorId: string,
-    @Query() pagination: OffsetPaginationDto,
-    @Query() filter: SearchTasksFilterDto,
-    @Query() sort: SearchTasksSortDto,
-    @Query() include: TaskIncludeDto
-  ): Promise<SearchTasksResponseDto> {
-    const [nodes, totalCount] = await this.taskService.search(
-      { skip: pagination.skip, take: pagination.take },
-      { ...filter, creatorId },
       sort,
       include
     );

--- a/apps/api/src/user/user.module.ts
+++ b/apps/api/src/user/user.module.ts
@@ -2,7 +2,6 @@ import { forwardRef, Module } from '@nestjs/common';
 
 import { AuthModule } from '@/auth/auth.module';
 import { PrismaModule } from '@/prisma/prisma.module';
-import { TaskModule } from '@/task/task.module';
 import { UsernameGeneratorModule } from '@/username-generator/username-generator.module';
 
 import { UserController } from './user.controller';
@@ -13,7 +12,6 @@ import { UserService } from './user.service';
     PrismaModule,
     forwardRef(() => AuthModule),
     UsernameGeneratorModule,
-    TaskModule,
   ],
   controllers: [UserController],
   providers: [UserService],


### PR DESCRIPTION
Move user tasks search from user controller to separate user-task controller in task module to keep user controller thin and avoid extra deps in user module.