### PR TITLE
Fix user display name generation

### DIFF
--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -45,8 +45,9 @@ export class UserService {
             username,
             displayName: username
               .split('-')
+              .slice(2)
               .map((part) => part[0]?.toUpperCase() + part.slice(1))
-              .join(),
+              .join(' '),
           },
         });
       } catch (error) {


### PR DESCRIPTION
Use only 2 first parts of username in display name generation, join them with space instead of comma.